### PR TITLE
Remove unneeded PR types

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,7 +1,5 @@
 name: Check PR on main
-on:
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
+on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previous types ran the action when closing (merging) the PR, which was unnecessary.