### PR TITLE
web: Make movie and member grids responsive to work on mobile

### DIFF
--- a/frontend/src/routes/MembersPage.css
+++ b/frontend/src/routes/MembersPage.css
@@ -4,7 +4,7 @@
   gap: 2rem;
 }
 
-@media (min-width: 600px) {
+@media (min-width: 1100px) {
   .members-grid {
     grid-template-columns: repeat(2, 1fr);
   }

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -17,8 +17,12 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   max-width: 100%;
+  overflow: hidden;
+  line-height: 1.3em;
+  max-height: 2.6em;
   min-height: 2.6em;
   margin: 0.5em 0 0.2em 0;
+  word-break: break-word;
 }
 
 .focus-box {


### PR DESCRIPTION
- Members page grid now shrinks to one column on smaller screens
- Hide overflow for movies with long titles (ensures consistent formatting for all movie cards)