### PR TITLE
web: Make modal responsive for thinner screens

### DIFF
--- a/frontend/src/components/MovieModal.css
+++ b/frontend/src/components/MovieModal.css
@@ -26,7 +26,7 @@
   padding: 0;
   border-radius: 15px;
   width: 90%;
-  max-width: 900px;
+  max-width: 75%;
   max-height: 82vh;
   overflow-y: auto;
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
@@ -44,6 +44,14 @@
   to {
     transform: translateY(0);
     opacity: 1;
+  }
+}
+@media (max-width: 900px) {
+  /* On mobile, make modal one column */
+  .modal-div {
+    flex-direction: column;
+    width: 60%;
+    height: 80%;
   }
 }
 


### PR DESCRIPTION
Change from the usual, 2-column look of the modal (poster on the left, information on the right) to a singular column when screen is too narrow.

Creep: Change the modal max-width to a percentage of the viewport instead of a pixel width.