### PR TITLE
web: Create new StarRating component

### DIFF
--- a/webapp/src/components/MovieModal.tsx
+++ b/webapp/src/components/MovieModal.tsx
@@ -1,5 +1,6 @@
-import { getAverageClubRating, starify, type Movie } from "../types/ApiTypes";
+import { getAverageClubRating, type Movie } from "../types/ApiTypes";
 import "./MovieModal.css";
+import StarRating from "./StarRating";
 
 export default function MovieModal({
   movie,
@@ -82,9 +83,7 @@ function RatingBox({ title, rating }: RatingBoxProps) {
       <div className="modal-ratings-highlight-box">
         <p className="modal-ratings-title">{title}</p>
         <div className="modal-ratings-values">
-          {rating !== null && (
-            <span className="modal-ratings-stars">{starify(rating * 2)}</span>
-          )}
+          {rating !== null && <StarRating rating={rating * 2} size={20} />}
           <span className="modal-ratings-number">
             {rating !== null ? rating.toFixed(2) : "N/A"}
           </span>
@@ -109,7 +108,7 @@ function ClubRatingBox({ name, rating }: ClubRatingBoxProps) {
   } else {
     score = (
       <div className="modal-club-rating-score">
-        <span className="modal-club-rating-stars">{starify(rating)}</span>
+        <StarRating rating={rating} size={15} />
         <span className="modal-club-rating-number">
           {(rating / 2).toFixed(1)}
         </span>

--- a/webapp/src/components/StarRating.tsx
+++ b/webapp/src/components/StarRating.tsx
@@ -1,0 +1,63 @@
+/**
+ * Generate an SVG representing the provided rating in star notation. `rating` must be a value between 0 and 10.
+ * If `rating` is null, then a default rating of 0 is used.
+ */
+export default function StarRating({
+  rating,
+  size,
+  color = "var(--star-gold-color)",
+}: {
+  rating: number | null;
+  size: number;
+  color?: string;
+}) {
+  if (rating === null) rating = 0;
+  if (rating < 0 || rating > 10) {
+    return <span>Invalid rating</span>;
+  }
+
+  const fullStarCnt = Math.floor(rating / 2);
+  const hasHalfStar = Math.round(rating) % 2 >= 1;
+  const emptyStarCnt = 5 - fullStarCnt - (hasHalfStar ? 1 : 0);
+
+  const stars = [];
+  const fullStars = Array(fullStarCnt).fill(
+    <svg id="U2605" width={size} height={size} viewBox="0 0 960 1000">
+      <path
+        transform="translate(0, 900) scale(1,-1)"
+        d="M480 186L202-17L309 301L51 474L367 474L480 815L595 474L909 474L651 301L760-17L480 186Z"
+        fill={color}
+      ></path>
+    </svg>,
+  );
+  stars.push(...fullStars);
+
+  if (hasHalfStar) {
+    stars.push(
+      <svg id="U2BEA" width={size} height={size} viewBox="0 0 947 1000">
+        <path
+          transform="translate(0, 900) scale(1,-1)"
+          d="M479 186L202-17L309 301L51 474L367 474L479 813L593 472L896 472L644 301L758-15L479 186ZM806 443L574 443L479 738L479 222L701 58L612 312L806 443Z"
+          fill={color}
+        ></path>
+      </svg>,
+    );
+  }
+
+  const emptyStars = Array(emptyStarCnt).fill(
+    <svg id="U2606" width={size} height={size} viewBox="0 0 1034 1000">
+      <path
+        transform="translate(0, 900) scale(1,-1)"
+        d="M517 174L214-48L331 298L51 484L392 484L517 856L642 484L983 484L703 298L818-48L517 174ZM403 321L324 103L517 249L710 103L631 321L807 435L596 435L517 676L437 435L225 435L403 321Z"
+        fill={color}
+      ></path>
+    </svg>,
+  );
+  stars.push(...emptyStars);
+
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center" }}>
+      {stars}
+    </span>
+  );
+}

--- a/webapp/src/routes/MembersPage.tsx
+++ b/webapp/src/routes/MembersPage.tsx
@@ -1,9 +1,9 @@
 import SmallMovieCard from "../components/SmallMovieCard";
+import StarRating from "../components/StarRating";
 import {
   getAverageMemberRating,
   GetMembersData,
   getMovieBySlug,
-  starify,
   type Movie,
 } from "../types/ApiTypes";
 import "./MembersPage.css";
@@ -39,9 +39,13 @@ export default function MembersPage({
                       movie={highestMovie}
                       onClick={onMovieClick}
                     />
-                    <p style={{ paddingTop: "1rem" }}>
-                      {starify(highestMovie.club_ratings[member.username])}
-                    </p>
+                    <div style={{ paddingTop: "15px" }}>
+                      <StarRating
+                        rating={highestMovie.club_ratings[member.username]}
+                        size={20}
+                        color="white"
+                      />
+                    </div>
                   </>
                 ) : (
                   <p>No highest rated movie yet</p>
@@ -55,9 +59,13 @@ export default function MembersPage({
                       movie={lowestMovie}
                       onClick={onMovieClick}
                     />
-                    <p style={{ paddingTop: "1rem" }}>
-                      {starify(lowestMovie.club_ratings[member.username])}
-                    </p>
+                    <div style={{ paddingTop: "15px" }}>
+                      <StarRating
+                        rating={lowestMovie.club_ratings[member.username]}
+                        size={20}
+                        color="white"
+                      />
+                    </div>
                   </>
                 ) : (
                   <p>No lowest rated movie yet</p>

--- a/webapp/src/types/ApiTypes.ts
+++ b/webapp/src/types/ApiTypes.ts
@@ -150,18 +150,3 @@ export function GetMembersData(data: Movie[]) {
 export function getMovieBySlug(data: Movie[], slug: string): Movie | null {
   return data.find((m) => m.slug === slug) ?? null;
 }
-
-/**
- * Converts a float value between 1 and 10 to a star notation
- * (with the following characters: ★, ⯪ and ☆)
- */
-export function starify(rating: number | null): string {
-  if (rating === null) rating = 0;
-  const fullStars = Math.floor(rating / 2);
-  const hasHalfStar = Math.round(rating) % 2 >= 1;
-  const emptyStars = 5 - fullStars - (hasHalfStar ? 1 : 0);
-  let stars = "★".repeat(fullStars);
-  if (hasHalfStar) stars += "⯪";
-  stars += "☆".repeat(emptyStars);
-  return stars;
-}


### PR DESCRIPTION
Create a new `StarRating` component to replace the `starify` function. The function used unicode characters to display full, half, and empty stars, but the new component uses SVG renders of those characters instead. This allows us to display stars even on devices that don't natively support rendering those characters.

Closes #11 