### PR TITLE
web: Remove `place-items: center` from body element

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -46,7 +46,6 @@
 body {
   margin: 0;
   display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
On very tall screens and pages without enough content to fully fill the height, this causes every item to be centered. This includes the navbar and results in a gap between the top of the window and the navbar.
<img width="1440" height="321" alt="image" src="https://github.com/user-attachments/assets/6681f724-b820-4f65-9d52-f89b3468348d" />
