### PR TITLE
scraper: Add `movies` and `users` CLI commands

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -82,7 +82,7 @@ impl AppState {
             .unwrap_or(FRONTEND_DIST_DIR.into())
             .into();
 
-        let state_dir: PathBuf = std::env::var("STATE_PATH")
+        let state_dir: PathBuf = std::env::var("STATE_DIRECTORY")
             .unwrap_or("./state/".into())
             .into();
 

--- a/nixos/modules/scraper-service.nix
+++ b/nixos/modules/scraper-service.nix
@@ -74,7 +74,7 @@ in
         User = "movie-club-scraper";
         Group = "movie-club";
         Type = "oneshot";
-        StateDirectory = "movie-club";
+        StateDirectory = "movie-club-scraper";
         ExecStart = ''
           ${lib.getExe cfg.package} list \
             --loglevel "${config.services.movie-club.scraper.loglevel}" \

--- a/nixos/modules/scraper-service.nix
+++ b/nixos/modules/scraper-service.nix
@@ -75,24 +75,22 @@ in
         Group = "movie-club";
         Type = "oneshot";
         StateDirectory = "movie-club";
-        ExecStart = "${lib.getExe cfg.package}";
+        ExecStart = ''
+          ${lib.getExe cfg.package} list \
+            --loglevel "${config.services.movie-club.scraper.loglevel}" \
+            --owner "${config.services.movie-club.scraper.list_owner}" \
+            --name "${config.services.movie-club.scraper.list_slug}" \
+            --users "${lib.strings.concatStringsSep "," config.services.movie-club.scraper.club_users}" \
+            --top-actor-count "${builtins.toString config.services.movie-club.scraper.top_actor_count}"'';
       };
-      environment = {
-        LIST_OWNER = config.services.movie-club.scraper.list_owner;
-        LIST_SLUG = config.services.movie-club.scraper.list_slug;
-        CLUB_USERS = lib.strings.concatStringsSep "," config.services.movie-club.scraper.club_users;
-        TOP_ACTOR_COUNT = builtins.toString config.services.movie-club.scraper.top_actor_count;
-        LOGLEVEL = config.services.movie-club.scraper.loglevel;
-      }
-      // (
-        # Only define envvar if optin is set
+      environment =
+        # Only define envvar if option is set
         if config.services.movie-club.scraper.output_dir != null then
           {
             OUTPUT_DIRECTORY = config.services.movie-club.scraper.output_dir;
           }
         else
-          { }
-      );
+          { };
     };
 
     systemd.timers.movie-club-scraper = {

--- a/nixos/modules/webapp-service.nix
+++ b/nixos/modules/webapp-service.nix
@@ -52,6 +52,7 @@ in
       serviceConfig = {
         DynamicUser = true;
         Type = "simple";
+        StateDirectory = "movie-club";
         ExecStart = "${lib.getExe cfg.package}";
       };
       environment = {

--- a/scraper/src/movie_club_scraper/__init__.py
+++ b/scraper/src/movie_club_scraper/__init__.py
@@ -143,6 +143,20 @@ def run_list(args: argparse.Namespace):
     logger.info(f"Stats written to {output_file}")
 
 
+def run_movies(args: argparse.Namespace):
+    top_actor_count: int = args.top_actor_count
+    slugs: list[str] = args.slugs.split(",")
+
+    logger.info(f"Scraping {len(slugs)} movies")
+
+    movies = []
+    for slug in slugs:
+        logger.info(f"Scraping {slug}...")
+        movies.append(get_movie_info(slug, top_actor_count))
+
+    output_formatted = [asdict(m) for m in movies]
+    print(json.dumps(output_formatted))
+
 def get_env_var(name: str, default: str | None = None) -> str:
     value = os.environ.get(name, default)
     if value is None:
@@ -165,6 +179,12 @@ def main():
     list_parser.add_argument("-n", "--name", "--slug", help="Name/URL slug of the list", required=True)
     list_parser.add_argument("-u", "--users", help="Comma-separated list of users to fetch info about", required=True)
     list_parser.add_argument("--top-actor-count", type=int, help="How many actors to keep while scraping actor list for each movie.", default=4)
+
+    # Movies command
+    movies_parser = subparsers.add_parser("movies", help="Scrape detailed information about the provided movies", parents=[common_parser])
+    movies_parser.set_defaults(func=run_movies)
+    movies_parser.add_argument("--top-actor-count", type=int, help="How many actors to keep while scraping actor list for each movie.", default=4)
+    movies_parser.add_argument("slugs", help="Comma-separated list of movie slugs")
 
     args = parser.parse_args()
 

--- a/scraper/src/movie_club_scraper/__init__.py
+++ b/scraper/src/movie_club_scraper/__init__.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import logging
 import os
@@ -85,13 +86,20 @@ def get_list_slugs(owner: str, slug: str) -> List[str]:
     return slugs
 
 
-def start(
-    list_owner: str,
-    list_slug: str,
-    club_users: List[str],
-    top_actor_count: int,
-    output_dir: str,
-):
+def run_list(args: argparse.Namespace):
+    # Get CLI args
+    list_owner: str = args.owner
+    list_slug: str = args.name
+    club_users: list[str] = args.users.split(",")
+    top_actor_count: int = args.top_actor_count
+
+    # For now, get OUTPUT_DIR from environment, but in the future, just print to stdout
+    output_dir = get_env_var("OUTPUT_DIRECTORY", default="")
+    if output_dir == "":
+        # Fallback to STATE_DIRECTORY
+        output_dir = get_env_var("STATE_DIRECTORY")
+
+
     slugs = get_list_slugs(list_owner, list_slug)
     logger.info(f"Found {len(slugs)} movie slugs in list")
 
@@ -138,30 +146,35 @@ def start(
 def get_env_var(name: str, default: str | None = None) -> str:
     value = os.environ.get(name, default)
     if value is None:
-        logger.fatal(f"{name} is not defined")
+        logger.fatal(f"Environment variable {name} is not defined")
         sys.exit(1)
     return value
 
 
 def main():
-    log_level = get_env_var("LOGLEVEL", default="INFO")
-    logging.basicConfig(level=log_level)
+    common_parser = argparse.ArgumentParser(add_help=False)
+    common_parser.add_argument("--loglevel", default=argparse.SUPPRESS, help="Log level, defaults to $LOGLEVEL")
 
-    list_owner = get_env_var("LIST_OWNER")
-    list_slug = get_env_var("LIST_SLUG")
-    club_users = get_env_var("CLUB_USERS").split(",")
-    output_dir = get_env_var("OUTPUT_DIRECTORY", default="")
-    if output_dir == "":
-        # Fallback to STATE_DIRECTORY
-        output_dir = get_env_var("STATE_DIRECTORY")
+    parser = argparse.ArgumentParser(prog="movie-club-scraper", parents=[common_parser])
+    subparsers = parser.add_subparsers(dest="command", required=True)
 
-    try:
-        top_actor_count = int(get_env_var("TOP_ACTOR_COUNT", default="4"))
-    except ValueError:
-        logger.fatal("Invalid TOP_ACTOR_COUNT value")
-        sys.exit(1)
+    # List command
+    list_parser = subparsers.add_parser("list", help="Scrape information about a Letterboxd list", parents=[common_parser])
+    list_parser.set_defaults(func=run_list)
+    list_parser.add_argument("-o", "--owner", help="Username of the list owner", required=True)
+    list_parser.add_argument("-n", "--name", "--slug", help="Name/URL slug of the list", required=True)
+    list_parser.add_argument("-u", "--users", help="Comma-separated list of users to fetch info about", required=True)
+    list_parser.add_argument("--top-actor-count", type=int, help="How many actors to keep while scraping actor list for each movie.", default=4)
 
-    start(list_owner, list_slug, club_users, top_actor_count, output_dir)
+    args = parser.parse_args()
+
+    if hasattr(args, "loglevel"):
+        loglevel = args.loglevel
+    else:
+        loglevel = get_env_var("LOGLEVEL", default="INFO")
+    logging.basicConfig(level=loglevel)
+
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/scraper/src/movie_club_scraper/__init__.py
+++ b/scraper/src/movie_club_scraper/__init__.py
@@ -228,6 +228,9 @@ def run_movies(args: argparse.Namespace):
         movies.append(get_movie_info(slug, top_actor_count))
 
     output_formatted = [asdict(m) for m in movies]
+    # Remove the `club_ratings` field, since it is always empty for this subcommand
+    for item in output_formatted:
+        item.pop("club_ratings", None)
     print(json.dumps(output_formatted))
 
 

--- a/scraper/src/movie_club_scraper/__init__.py
+++ b/scraper/src/movie_club_scraper/__init__.py
@@ -44,6 +44,17 @@ class MovieInfo:
     top_actors: List[str]
     club_ratings: Dict[str, int | None] = field(init=False, default_factory=dict)
 
+@dataclass
+class UserInfo:
+    username: str
+    watchlist_length: int
+    watched_films_total: int
+    watched_films_current_year: int
+    favorite_slugs: list[str]
+    avatar_url: Optional[str]
+    recent_watchlist_slugs: list[str]
+    recent_watched_slugs: list[str]
+
 
 def get_movie_info(slug: str, top_actor_count: int) -> MovieInfo:
     movie_instance = Movie(slug)
@@ -84,6 +95,69 @@ def get_list_slugs(owner: str, slug: str) -> List[str]:
     for movie_dict in list_movies.values():
         slugs.append(movie_dict["slug"])
     return slugs
+
+
+def get_user_info(username: str, recent_count: int) -> UserInfo:
+    user_instance = User(username)
+
+    watched_films_total = user_instance.stats.get("films", 0)
+    watched_films_current_year = user_instance.stats.get("this_year", 0)
+
+    favorite_slugs = []
+    for entry in user_instance.favorites.values():
+        slug = entry.get("slug")
+        if slug is not None:
+            favorite_slugs.append(slug)
+
+    avatar_dict: dict[str, str] = user_instance.avatar #type: ignore
+    avatar_exists  = avatar_dict.get("exists", False)
+    if avatar_exists:
+        avatar_url = avatar_dict.get("url")
+    else:
+        avatar_url = None
+
+    # Extract recent watchlist and watched
+    recent_watchlist = user_instance.recent["watchlist"]
+    recent_watchlist_slugs = []
+    for entry in recent_watchlist.values():
+        slug = entry.get("slug")
+        if slug is not None:
+            recent_watchlist_slugs.append(slug)
+            if len(recent_watchlist_slugs) >= recent_count:
+                # List is full
+                break
+
+    # The diary dict has a key "months" filled with string values from "1" to "12".
+    # Each month points to a dict whose keys are days (str) and values are arrays.
+    # It seems like the keys are time-sorted, meaning January appears before December
+    # (even if 1 is smaller than 12)
+    diary: dict[str, dict] = user_instance.recent["diary"]
+    # Since the diary has nested loops, make this a function
+    def parse_diary(diary: dict[str, dict]) -> list[str]:
+        recent_watched: dict[str, dict[str, list[dict[str, str]]]] = diary["months"]
+        output = []
+        for (month, month_dict) in recent_watched.items():
+            for (day, movies) in month_dict.items():
+                for movie in movies:
+                    slug = movie.get("slug")
+                    if slug is not None:
+                        output.append(slug)
+                        if len(output) >= recent_count:
+                            # List is full
+                            return output
+        return output
+    recent_watched_slugs = parse_diary(diary)
+
+    return UserInfo(
+        username=user_instance.username,
+        watchlist_length=user_instance.watchlist_length,
+        watched_films_total=watched_films_total,
+        watched_films_current_year=watched_films_current_year,
+        favorite_slugs=favorite_slugs,
+        avatar_url=avatar_url,
+        recent_watchlist_slugs=recent_watchlist_slugs,
+        recent_watched_slugs=recent_watched_slugs
+    )
 
 
 def run_list(args: argparse.Namespace):
@@ -146,7 +220,6 @@ def run_list(args: argparse.Namespace):
 def run_movies(args: argparse.Namespace):
     top_actor_count: int = args.top_actor_count
     slugs: list[str] = args.slugs.split(",")
-
     logger.info(f"Scraping {len(slugs)} movies")
 
     movies = []
@@ -156,6 +229,21 @@ def run_movies(args: argparse.Namespace):
 
     output_formatted = [asdict(m) for m in movies]
     print(json.dumps(output_formatted))
+
+
+def run_users(args: argparse.Namespace):
+    usernames: list[str] = args.usernames.split(",")
+    recent_count: int = args.recent_count
+    logger.info(f"Scraping {len(usernames)} users")
+
+    users = []
+    for username in usernames:
+        logger.info(f"Scraping {username}...")
+        users.append(get_user_info(username, recent_count))
+
+    output_formatted = [asdict(u) for u in users]
+    print(json.dumps(output_formatted))
+
 
 def get_env_var(name: str, default: str | None = None) -> str:
     value = os.environ.get(name, default)
@@ -178,13 +266,19 @@ def main():
     list_parser.add_argument("-o", "--owner", help="Username of the list owner", required=True)
     list_parser.add_argument("-n", "--name", "--slug", help="Name/URL slug of the list", required=True)
     list_parser.add_argument("-u", "--users", help="Comma-separated list of users to fetch info about", required=True)
-    list_parser.add_argument("--top-actor-count", type=int, help="How many actors to keep while scraping actor list for each movie.", default=4)
+    list_parser.add_argument("--top-actor-count", type=int, help="How many actors to keep while scraping actor list for each movie", default=4)
 
     # Movies command
     movies_parser = subparsers.add_parser("movies", help="Scrape detailed information about the provided movies", parents=[common_parser])
     movies_parser.set_defaults(func=run_movies)
-    movies_parser.add_argument("--top-actor-count", type=int, help="How many actors to keep while scraping actor list for each movie.", default=4)
+    movies_parser.add_argument("--top-actor-count", type=int, help="How many actors to keep while scraping actor list for each movie", default=4)
     movies_parser.add_argument("slugs", help="Comma-separated list of movie slugs")
+
+    # Users command
+    users_parser = subparsers.add_parser("users", help="Scrape detailed information about the provided users", parents=[common_parser])
+    users_parser.set_defaults(func=run_users)
+    users_parser.add_argument("--recent-count", type=int, help="How many recently watched/watchlisted movies to scrape for each user", default=4)
+    users_parser.add_argument("usernames", help="Comma-separated list of Letterboxd usernames")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
## Migration to CLI arguments
The previous default behaviour was to scrape a Letterboxd list based on a few environment variables defining which list to scrape. This logic can now be executed by running `movie-club-scraper list`, with the parameters provided as CLI arguments instead of environment variables. For now, only `OUTPUT_DIRECTORY` remains as an environment variable.

The scraper nix service was updated to use CLI arguments instead of environment variables.

## New CLI actions
Two new subcommands, `movies` and `users`, allow to scrape detailed information for a provided list of movies or users, respectively. Unlike the `list` subcommand, these two new commands do not need an `OUTPUT_DIRECTORY` and instead output the JSON to stdout.

### `movies` subcommand
The output looks like:
```json
[
  {
    "slug": "str",
    "poster_url": "str",
    "title": "str",
    "year": 0,
    "runtime": 0,
    "avg_rating": 0.0,
    "director": {
      "name": "str",
      "slug": "str",
      "url": "str"
    },
    "top_actors": [
      {
        "slug": "str",
        "name": "str",
        "role_name": "str"
      },
      ...
    ]
  },
  ...
]

```

### `users` subcommand
The output looks like:
```json
[
  {
    "username": "str",
    "watchlist_length": 0,
    "watched_films_total": 0,
    "watched_films_current_year": 0,
    "favorite_slugs": [
      "str",
      ...
    ],
    "avatar_url": "str",
    "recent_watchlist_slugs": [
      "str",
      ...
    ],
    "recent_watched_slugs": [
      "str",
      ...
    ]
  }
]

```

## Creep
The backend read `STATE_PATH` as the directory to store the state files in, but systemd uses `STATE_DIRECTORY`. To freely make use of systemd's logic, changed which variable we use. Also some small refactor to the nix services to ensure they don't both use the same directory.

Closes #23 